### PR TITLE
Fix whitespace errors and dependency issues

### DIFF
--- a/provisioning/python/tasks/python-packages.yml
+++ b/provisioning/python/tasks/python-packages.yml
@@ -17,7 +17,7 @@
     - python-packages
 
 - name: Install llvlite for numba
-  shell: sudo sh -c "LLVM_CONFIG=/usr/bin/llvm-config-3.5 pip install llvmlite"
+  shell: sudo sh -c "LLVM_CONFIG=/usr/bin/llvm-config-3.6 pip install llvmlite"
   tags: 
     - python-packages
 

--- a/provisioning/python/tasks/python-packages.yml
+++ b/provisioning/python/tasks/python-packages.yml
@@ -31,7 +31,7 @@
   tags:
     - python-packages
 
- - name: Install mysql-connector-python
-   pip: name=mysql-connector-python state=latest extra_args='--allow-external mysql-connector-python'
-   tags:
+- name: Install mysql-connector-python
+  pip: name=mysql-connector-python state=latest extra_args='--allow-external mysql-connector-python'
+  tags:
     - python-packages

--- a/provisioning/python/vars/main.yml
+++ b/provisioning/python/vars/main.yml
@@ -11,7 +11,8 @@ apt_packages:
   - zlib1g-dev #lxml
   - libffi-dev #scrapy
   - libssl-dev #scrapy
-  - llvm-3.5-dev #numba
+  - llvm-3.6-dev #numba
+  - libedit-dev #numba
   - libopenblas-dev 
   - liblapack-dev
   - gfortran


### PR DESCRIPTION
Issues solved:
- Indentation of <code>provisioning/python/tasks/python-packages.yml</code> leads to ansible failing.
- Current numba version needs llvm-3.6 and libedit-dev.
